### PR TITLE
pywin32 references removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://www.youtube.com/watch?v=G92neaVfvyw
 ## Installation
 
 1. **Install and test the standard Hamilton software suite for your system.** We no longer host the link here, please contact Hamilton for a copy of the Venus 4 software if you don't have one already
-2. **Install 32-bit python <=3.9**, preferably using the executable installer at https://www.python.org/downloads/release/python-390/. Python 3.10+ is known to cause an installation issue with some required pythonnet/pywin32 modules.
+2. **Install 32-bit python <=3.9**, preferably using the executable installer at https://www.python.org/downloads/release/python-390/. Python 3.10+ is known to cause an installation issue with some required pythonnet modules.
 3. **Make sure git is installed.** https://git-scm.com/download/win
 4. **Make sure you have .NET framework 4.0 or higher installed.** https://www.microsoft.com/en-us/download/details.aspx?id=17851
 5. **Update your pip and setuptools.**

--- a/imgs/README.md
+++ b/imgs/README.md
@@ -14,7 +14,7 @@ PyHamilton is an open-source Python interface for programming Hamilton liquid-ha
  ## Installation
 
 1. **Install and test the standard Hamilton software suite for your system.**
-2. **Install 32-bit python <=3.9**, preferably using the executable installer at https://www.python.org/downloads/release/python-390/. Python 3.10+ is known to cause an installation issue with some required pythonnet/pywin32 modules.
+2. **Install 32-bit python <=3.9**, preferably using the executable installer at https://www.python.org/downloads/release/python-390/. Python 3.10+ is known to cause an installation issue with some required pythonnet modules.
 3. **Make sure git is installed.** https://git-scm.com/download/win
 4. **Make sure you have .NET framework 4.0 or higher installed.** https://www.microsoft.com/en-us/download/details.aspx?id=17851
 5. **Update your pip and setuptools.**

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,6 +3,5 @@ parse
 pytest
 pytest-mock
 pythonnet --pre
-pywin32==300
 pyserial
 waiter

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license='MIT',
     description='Python for Hamilton liquid handling robots',
     long_description='Forthcoming due to markdown incompatibility',
-    install_requires=['requests', 'pythonnet', 'pywin32', 'pyserial', 'parse', 'waiter'],
+    install_requires=['requests', 'pythonnet', 'pyserial', 'parse', 'waiter'],
     package_data={'pyhamilton': ['star-oem/*', 'star-oem/VENUS_Method/*', 'bin/*','library/*','project-template/*',
                                  'library/HSLInhecoTEC/*','library/HSLAppsLib/*','library/ASWStandard/*',
                                  'library/ASWStandard/ASWGlobal/*','library/ASWStandard/TraceLevel/*',


### PR DESCRIPTION
Some leftover of **pywin32** removed.
Specifically, **pywin32** in `setup.py` file raise warnings/errors during package build/installation.